### PR TITLE
simple fix for issue #4

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -63,15 +63,17 @@ class SoftDeleteQuerySet(query.QuerySet):
             cs.undelete()
         logging.debug("FINISHED UNDELETING %s" %self)
 
-
 class SoftDeleteManager(models.Manager):
     def get_query_set(self):
         qs = super(SoftDeleteManager,self).get_query_set().filter(deleted_at__isnull=1)
         qs.__class__ = SoftDeleteQuerySet
         return qs
 
-    def all_with_deleted(self):
-        qs = super(SoftDeleteManager, self).get_query_set()
+    def all_with_deleted(self, prt=False):
+        if hasattr(self, 'core_filters'): # it's a RelatedManager
+            qs = super(SoftDeleteManager, self).get_query_set().filter(**self.core_filters)
+        else:
+            qs = super(SoftDeleteManager, self).get_query_set()
         qs.__class__ = SoftDeleteQuerySet
         return qs
 

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -8,10 +8,11 @@ class TestModelOne(SoftDeleteObject):
     
 class TestModelTwo(SoftDeleteObject):
     extra_int = models.IntegerField()
-    tmo = models.ForeignKey(TestModelOne,related_name='tmos')
+    tmo = models.ForeignKey(TestModelOne,related_name='tmts')
     
 class TestModelThree(SoftDeleteObject):
     tmos = models.ManyToManyField(TestModelOne, through='TestModelThrough')
+    extra_int = models.IntegerField(blank=True, null=True)
 
 class TestModelThrough(SoftDeleteObject):
     tmo1 = models.ForeignKey(TestModelOne, related_name="left_side")


### PR DESCRIPTION
Simple fix for the issue #4, with tests.
I modified the test_app's models a little bit to test the behavior in many2many relationships.

I also think this is a simple monkeypatch to this problem, the real solution might be adding a "SoftDeleteForeignKey" (and "SoftDeleteManyToMany") that would create its own "SoftDeleteForeignRelatedObjectsDescriptor" (which creates the RelatedManager) when `contribute_to_related_class` is called, this way we could keep the api for multiple database support: using django.db.router to try and guess the db_for_read for the given instance, if any. I didn't implement this because I think there is a design decision required (and cause I got no time =)
