### PR TITLE
fix append problem in tests

### DIFF
--- a/softdelete/tests/__init__.py
+++ b/softdelete/tests/__init__.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from softdelete.tests.test_sd import *
 from softdelete.tests.test_views import *
 
-settings.INSTALLED_APPS.append('softdelete.test_softdelete_app')
+settings.INSTALLED_APPS += ('softdelete.test_softdelete_app',)
 loading.cache.loaded = False
 call_command('syncdb', interactive=False, verbosity=False)
 


### PR DESCRIPTION
Fixes error message `tuple has no attribute append`.

From django documentation:

> ### INSTALLED_APPS
> 
> Default: () (Empty tuple)
> A tuple of strings designating all applications that are enabled in this Django installation....

So the test should expect a tuple not a list.
