### PR TITLE
Fix error when trying to delete nonexisting related attribute

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -122,6 +122,11 @@ class SoftDeleteObject(models.Model):
 
     def _do_delete(self, changeset, related):
         rel = related.get_accessor_name()
+        
+        # Sometimes there is nothing to delete
+        if not hasattr(self, rel):
+            return
+        
         try:
             getattr(self, rel).all().delete(changeset=changeset)
         except:


### PR DESCRIPTION
An error would happen when trying to access the reverse of a foreign key relationship which had not been created. This fixes it. Cheers.
