### PR TITLE
Use a charfield to store ids

### DIFF
--- a/softdelete/migrations/0003_auto__chg_field_softdeleterecord_object_id__chg_field_changeset_object.py
+++ b/softdelete/migrations/0003_auto__chg_field_softdeleterecord_object_id__chg_field_changeset_object.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'SoftDeleteRecord.object_id'
+        db.alter_column(u'softdelete_softdeleterecord', 'object_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+        # Changing field 'ChangeSet.object_id'
+        db.alter_column(u'softdelete_changeset', 'object_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+    def backwards(self, orm):
+
+        # Changing field 'SoftDeleteRecord.object_id'
+        db.alter_column(u'softdelete_softdeleterecord', 'object_id', self.gf('django.db.models.fields.PositiveIntegerField')())
+
+        # Changing field 'ChangeSet.object_id'
+        db.alter_column(u'softdelete_changeset', 'object_id', self.gf('django.db.models.fields.PositiveIntegerField')())
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'softdelete.changeset': {
+            'Meta': {'object_name': 'ChangeSet'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'softdelete.softdeleterecord': {
+            'Meta': {'unique_together': "(('changeset', 'content_type', 'object_id'),)", 'object_name': 'SoftDeleteRecord'},
+            'changeset': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'soft_delete_records'", 'to': u"orm['softdelete.ChangeSet']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'created_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['softdelete']

--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -19,17 +19,17 @@ except:
 def _determine_change_set(obj, create=True):
     try:
         qs = SoftDeleteRecord.objects.filter(content_type=ContentType.objects.get_for_model(obj),
-                                             object_id=obj.pk).latest('created_date').changeset
+                                             object_id=str(obj.pk)).latest('created_date').changeset
         logging.debug("Found changeset via latest recordset")
     except:
         try:
             qs = ChangeSet.objects.filter(content_type=ContentType.objects.get_for_model(obj),
-                                          object_id=obj.pk).latest('created_date')
+                                          object_id=str(obj.pk)).latest('created_date')
             logging.debug("Found changeset")
         except:
             if create:
                 qs = ChangeSet.objects.create(content_type=ContentType.objects.get_for_model(obj),
-                                              object_id=obj.pk)
+                                              object_id=str(obj.pk))
                 logging.debug("Creating changeset")
             else:
                 logging.debug("Raising ObjectDoesNotExist")
@@ -50,7 +50,7 @@ class SoftDeleteQuerySet(query.QuerySet):
         for obj in self:
             rs, c = SoftDeleteRecord.objects.get_or_create(changeset=cs or _determine_change_set(obj),
                                                            content_type=ContentType.objects.get_for_model(obj),
-                                                           object_id=obj.pk)
+                                                           object_id=str(obj.pk))
             logging.debug(" -----  CALLING delete() on %s" % obj)
             obj.delete(using, *args, **kwargs)        
 

--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -229,7 +229,7 @@ class SoftDeleteObject(models.Model):
 class ChangeSet(models.Model):
     created_date = models.DateTimeField(default=timezone.now)
     content_type = models.ForeignKey(ContentType)
-    object_id = models.PositiveIntegerField()
+    object_id = models.CharField(max_length=100)
     record = generic.GenericForeignKey('content_type', 'object_id')
 
     def get_content(self):
@@ -256,7 +256,7 @@ class SoftDeleteRecord(models.Model):
     changeset = models.ForeignKey(ChangeSet, related_name='soft_delete_records')
     created_date = models.DateTimeField(default=timezone.now)
     content_type = models.ForeignKey(ContentType)
-    object_id = models.PositiveIntegerField()
+    object_id = models.CharField(max_length=100)
     record = generic.GenericForeignKey('content_type', 'object_id')
 
     class Meta:


### PR DESCRIPTION
For some models I am using uuid fields this cannot be stored in the current models of softdelete.

As a bypass I know use a Charfield with max length 100 to store the id's of the deleted records.
It needs a migration!

Don't know if there is a great performance issue...