### PR TITLE
Use get_queryset and get_ordering for admin models

### DIFF
--- a/softdelete/admin/admin.py
+++ b/softdelete/admin/admin.py
@@ -23,6 +23,13 @@ class SoftDeleteObjectInline(admin.TabularInline):
             qs = qs.order_by(*ordering)
         return qs
 
+    def get_queryset(self, request):
+        qs = self.model._default_manager.all_with_deleted()
+        ordering = self.get_ordering or ()
+        if ordering:
+            qs = qs.order_by(*ordering)
+        return qs
+
 class SoftDeleteObjectAdmin(admin.ModelAdmin):
     form = SoftDeleteObjectAdminForm
     actions = ['delete_selected', 'soft_undelete']
@@ -51,6 +58,16 @@ class SoftDeleteObjectAdmin(admin.ModelAdmin):
             qs = qs.order_by(*ordering)
         return qs
 
+    def get_queryset(self, request):
+        try:
+            qs = self.model._default_manager.all_with_deleted()
+        except Exception as ex:
+            qs = self.model._default_manager.all()
+
+        ordering = self.get_ordering or ()
+        if ordering:
+            qs = qs.order_by(*ordering)
+        return qs
 
 class SoftDeleteRecordInline(admin.TabularInline):
     model = SoftDeleteRecord
@@ -70,7 +87,7 @@ class SoftDeleteRecordAdmin(admin.ModelAdmin):
     def response_change(self, request, obj, *args, **kwargs):
         if request.POST.has_key('undelete'):
             obj.undelete()
-            return HttpResponseRedirect('../')
+            return HttpResponseRedirect('../../')
         return super(SoftDeleteRecordAdmin, self).response_change(request, obj, 
                                                                   *args, **kwargs)
 
@@ -93,7 +110,7 @@ class ChangeSetAdmin(admin.ModelAdmin):
     def response_change(self, request, obj, *args, **kwargs):
         if request.POST.has_key('undelete'):
             obj.undelete()
-            return HttpResponseRedirect('../')
+            return HttpResponseRedirect('../../')
         return super(ChangeSetAdmin, self).response_change(request, obj, 
                                                            *args, **kwargs)
 


### PR DESCRIPTION
Using Django 1.9.4, the methods queryset and ordering don't seem to get executed on admin models.
For backwards compatibility, the old methods have been left untouched.
The redirect on successfully undeleting a changeset or deleterecord was returning a 404, and is now changed to correctly redirect to the base view. If in the old version, the redirect was correct, then I'll need to update my pull request with version conditional logic.