### PR TITLE
remove has_key usage from project to be python 3 compatible

### DIFF
--- a/softdelete/admin/admin.py
+++ b/softdelete/admin/admin.py
@@ -43,7 +43,7 @@ class SoftDeleteObjectAdmin(admin.ModelAdmin):
     soft_undelete.short_description = 'Undelete selected objects'
 
     def response_change(self, request, obj, *args, **kwargs):
-        if request.POST.has_key('undelete'):
+        if 'undelete' in request.POST:
             return HttpResponseRedirect('../')
         return super(SoftDeleteObjectAdmin, self).response_change(request, obj, *args, **kwargs)
 
@@ -85,7 +85,7 @@ class SoftDeleteRecordAdmin(admin.ModelAdmin):
     soft_undelete.short_description = 'Undelete selected objects'
 
     def response_change(self, request, obj, *args, **kwargs):
-        if request.POST.has_key('undelete'):
+        if 'undelete' in request.POST:
             obj.undelete()
             return HttpResponseRedirect('../../')
         return super(SoftDeleteRecordAdmin, self).response_change(request, obj, 
@@ -108,7 +108,7 @@ class ChangeSetAdmin(admin.ModelAdmin):
     soft_undelete.short_description = 'Undelete selected objects'
 
     def response_change(self, request, obj, *args, **kwargs):
-        if request.POST.has_key('undelete'):
+        if 'undelete' in request.POST:
             obj.undelete()
             return HttpResponseRedirect('../../')
         return super(ChangeSetAdmin, self).response_change(request, obj, 

--- a/softdelete/admin/forms.py
+++ b/softdelete/admin/forms.py
@@ -18,7 +18,7 @@ class SoftDeleteObjectAdminForm(ModelForm):
 
     def clean(self, *args, **kwargs):
         cleaned_data = super(SoftDeleteObjectAdminForm, self).clean(*args, **kwargs)
-        if self.data.has_key('undelete'):
+        if 'undelete' in self.data:
             self.instance.deleted = False
             cleaned_data['deleted'] = False
         return cleaned_data

--- a/softdelete/tests/test_views.py
+++ b/softdelete/tests/test_views.py
@@ -32,7 +32,7 @@ class ViewBase(TestCase):
 class ViewTest(ViewBase):
     def __init__(self, *args, **kwargs):
         settings.USE_SOFTDELETE_GROUP = kwargs.get('USE_SOFTDELETE_GROUP', False)
-        if kwargs.has_key('USE_SOFTDELETE_GROUP'):
+        if 'USE_SOFTDELETE_GROUP' in kwargs:
             del kwargs['USE_SOFTDELETE_GROUP']
         super(ViewTest, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Using `in` instead of `has_key` is still Python 2 compatible. Tangentially, the use of `in` seems to be the preferred pythonic way to check if a key exists in a dictionary (see http://stackoverflow.com/questions/1323410/has-key-or-in).