### PR TITLE
soft deletes for one to one relations

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -164,7 +164,10 @@ class SoftDeleteObject(models.Model):
             return
 
         try:
-            getattr(self, rel).all().delete(changeset=changeset)
+            if related.one_to_one:
+                getattr(self, rel).delete(changeset=changeset)
+            else:
+                getattr(self, rel).all().delete(changeset=changeset)
         except:
             try:
                 getattr(self, rel).all().delete()


### PR DESCRIPTION
When we don't do this check, unrelated model instances start to get soft deleted, and we end up with 1k+ count changesets.