### PR TITLE
`get()` returns deleted objects only when querying by `pk` parameter.

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -117,7 +117,10 @@ class SoftDeleteManager(models.Manager):
         return qs
 
     def get(self, *args, **kwargs):
-        return self.all_with_deleted().get(*args, **kwargs)
+        if 'pk' in kwargs:
+            return self.all_with_deleted().get(*args, **kwargs)
+        else:
+            return self._get_self_queryset().get(*args, **kwargs)
 
     def filter(self, *args, **kwargs):
         if 'pk' in kwargs:


### PR DESCRIPTION
This change makes calling `filter()` and `get()` more consistent.