### PR TITLE
Fixed deleted_at field definition.

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -135,7 +135,10 @@ class SoftDeleteManager(models.Manager):
 
 
 class SoftDeleteObject(models.Model):
-    deleted_at = models.DateTimeField(blank=True, null=True, default=None)
+    deleted_at = models.DateTimeField(
+        blank=True, null=True, default=None,
+        editable=False, db_index=True
+    )
     objects = SoftDeleteManager()
 
     class Meta:


### PR DESCRIPTION
I guess `deleted_at` shouldn't be editable.
I was unable to run tests - it seems that test configuration is broken, `python setup.py test` doesn't work and `README.md` doesn't have information about how to run the tests. But I'm pretty sure this change shouldn't break anything.