### PR TITLE
Allow SoftDeleteManager to use custom queryset

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ through-the-web undelete support.
 
 Usage
 =====
-
-- For the models that you want __soft delete__ to be implemented in, inherit from the `SoftDeleteObject`. Something like `MyCustomModel(SoftDeleteObject, models.Model)`. This will add an extra `deleted_at` field which will appear in the admin form after deleting/ undeleting the object
+- Run `django-admin migrate`
+- For the models that you want __soft delete__ to be implemented in, inherit from the `SoftDeleteObject` with `from softdelete.models import SoftDeleteObject`. Something like `MyCustomModel(SoftDeleteObject, models.Model)`. This will add an extra `deleted_at` field which will appear in the admin form after deleting/undeleting the object
 - If you have a custom manager also make sure to inherit from the `SoftDeleteManager`.
 - After that you can test it by __deleting__ and __undeleting__ objects from your models. Have fun undeleting :)
 

--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -96,13 +96,15 @@ class SoftDeleteManager(models.Manager):
     def get_query_set(self):
         qs = super(SoftDeleteManager, self).get_query_set().filter(
             deleted_at__isnull=True)
-        qs.__class__ = SoftDeleteQuerySet
+        if not issubclass(qs.__class__, SoftDeleteQuerySet):
+            qs.__class__ = SoftDeleteQuerySet
         return qs
 
     def get_queryset(self):
         qs = super(SoftDeleteManager, self).get_queryset().filter(
             deleted_at__isnull=True)
-        qs.__class__ = SoftDeleteQuerySet
+        if not issubclass(qs.__class__, SoftDeleteQuerySet):
+            qs.__class__ = SoftDeleteQuerySet
         return qs
 
     def all_with_deleted(self, prt=False):
@@ -110,12 +112,14 @@ class SoftDeleteManager(models.Manager):
             qs = self._get_base_queryset().filter(**self.core_filters)
         else:
             qs = self._get_base_queryset()
-        qs.__class__ = SoftDeleteQuerySet
+        if not issubclass(qs.__class__, SoftDeleteQuerySet):
+            qs.__class__ = SoftDeleteQuerySet
         return qs
 
     def deleted_set(self):
         qs = self._get_base_queryset().filter(deleted_at__isnull=0)
-        qs.__class__ = SoftDeleteQuerySet
+        if not issubclass(qs.__class__, SoftDeleteQuerySet):
+            qs.__class__ = SoftDeleteQuerySet
         return qs
 
     def get(self, *args, **kwargs):
@@ -129,7 +133,8 @@ class SoftDeleteManager(models.Manager):
             qs = self.all_with_deleted().filter(*args, **kwargs)
         else:
             qs = self._get_self_queryset().filter(*args, **kwargs)
-        qs.__class__ = SoftDeleteQuerySet
+        if not issubclass(qs.__class__, SoftDeleteQuerySet):
+            qs.__class__ = SoftDeleteQuerySet
         return qs
 
 


### PR DESCRIPTION
I am not able to use `SoftDeleteManager` with a custom queryset.
Here's what I'm attempting to do:
```python
class CustomQuerySet(SoftDeleteQuerySet):
    def unanswered(self):
        return self.filter(response=None)

CustomManager = SoftDeleteManager.from_queryset(CustomQuerySet)

class Model:
    ...
    objects = CustomManager()
```
When I do `Model.objects.unanswered()`, I get `AttributeError: 'SoftDeleteQuerySet' object has no attribute 'unanswered'
`
It's because in `SoftDeleteManager`, it is overriding the queryset class to `SoftDeleteQuerySet`. But in my situation, I want to use my custom queryset that inherits from `SoftDeleteQuerySet`.

I propose only overriding the queryset class if the current queryset class is not a subclass of `SoftDeleteQuerySet`.