### PR TITLE
Support django 4.0

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -117,7 +117,7 @@ class SoftDeleteManager(models.Manager):
         return qs
 
     def deleted_set(self):
-        qs = self._get_base_queryset().filter(deleted_at__isnull=0)
+        qs = self._get_base_queryset().filter(deleted_at__isnull=False)
         if not issubclass(qs.__class__, SoftDeleteQuerySet):
             qs.__class__ = SoftDeleteQuerySet
         return qs

--- a/softdelete/signals.py
+++ b/softdelete/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-pre_soft_delete = Signal(providing_args=['instance'])
-post_soft_delete = Signal(providing_args=['instance'])
-pre_undelete = Signal(providing_args=['instance'])
-post_undelete = Signal(providing_args=['instance'])
+pre_soft_delete = Signal()
+post_soft_delete = Signal()
+pre_undelete = Signal()
+post_undelete = Signal()

--- a/softdelete/urls.py
+++ b/softdelete/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url, include
+from django.urls import include, re_path
 from softdelete.views import *
 
 urlpatterns = [
-    url(r'^changeset/(?P<changeset_pk>\d+?)/undelete/$',
+    re_path(r'^changeset/(?P<changeset_pk>\d+?)/undelete/$',
         ChangeSetUpdate.as_view(),
         name="softdelete.changeset.undelete"),
-    url(r'^changeset/(?P<changeset_pk>\d+?)/$',
+    re_path(r'^changeset/(?P<changeset_pk>\d+?)/$',
         ChangeSetDetail.as_view(),
         name="softdelete.changeset.view"),
-    url(r'^changeset/$',
+    re_path(r'^changeset/$',
         ChangeSetList.as_view(),
         name="softdelete.changeset.list"),
 ]
@@ -24,5 +24,5 @@ if 'test' in sys.argv:
         urlpatterns.append(path('admin/', admin.site.urls))
         urlpatterns.append(path('accounts/', include('django.contrib.auth.urls')))
     else:
-        urlpatterns.append(url(r'^admin/', include(admin.site.urls)))
-        urlpatterns.append(url(r'^accounts/', include('django.contrib.auth.urls')))
+        urlpatterns.append(re_path(r'^admin/', include(admin.site.urls)))
+        urlpatterns.append(re_path(r'^accounts/', include('django.contrib.auth.urls')))

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
-envlist = py27-A, py27-B, py27-C, py27-D,
-          py34-A, py34-B, py34-C, py34-D, py34-E,
-          py35-A, py35-B, py35-C, py35-D, py35-E, py35-F, py35-G,
-          py36-A, py36-B, py36-C, py36-D, py36-E, py36-F, py36-G,
-          py37-A, py37-B, py37-C, py37-D, py37-E, py37-F, py37-G
+envlist = py34-E,
+          py35-E, py35-F, py35-G,
+          py36-E, py36-F, py36-G,
+          py37-E, py37-F, py37-G, py37-H, py37-I, py37-J,
+          py38-E, py38-F, py38-G, py38-H, py38-I, py38-J, py38-K,
+          py39-E, py39-F, py39-G, py39-H, py39-I, py39-J, py39-K,
+          py310-E, py310-F, py310-G, py310-H, py310-I, py310-J, py310-K
 skip_missing_interpreters=True
 
 [testenv]
@@ -12,70 +14,10 @@ commands = django-admin test --settings softdelete.settings
 usedevelop = True
 deps =
 
-[testenv:py27-A]
-basepython = python2.7
-deps = {[testenv]deps}
-    Django>=1.8,<1.9
-
-[testenv:py27-B]
-basepython = python2.7
-deps = {[testenv]deps}
-    Django>=1.9,<1.10
-
-[testenv:py27-C]
-basepython = python2.7
-deps = {[testenv]deps}
-    Django>=1.10,<1.11
-
-[testenv:py27-D]
-basepython = python2.7
-deps = {[testenv]deps}
-    Django>=1.11,<2.0
-
-[testenv:py34-A]
-basepython = python3.4
-deps = {[testenv]deps}
-    Django>=1.8,<1.9
-
-[testenv:py34-B]
-basepython = python3.4
-deps = {[testenv]deps}
-    Django>=1.9,<1.10
-
-[testenv:py34-C]
-basepython = python3.4
-deps = {[testenv]deps}
-    Django>=1.10,<1.11
-
-[testenv:py34-D]
-basepython = python3.4
-deps = {[testenv]deps}
-    Django>=1.11,<2.0
-
 [testenv:py34-E]
 basepython = python3.4
 deps = {[testenv]deps}
     Django>=2.0,<2.1
-
-[testenv:py35-A]
-basepython = python3.5
-deps = {[testenv]deps}
-    Django>=1.8,<1.9
-
-[testenv:py35-B]
-basepython = python3.5
-deps = {[testenv]deps}
-    Django>=1.9,<1.10
-
-[testenv:py35-C]
-basepython = python3.5
-deps = {[testenv]deps}
-    Django>=1.10,<1.11
-
-[testenv:py35-D]
-basepython = python3.5
-deps = {[testenv]deps}
-    Django>=1.11,<2.0
 
 [testenv:py35-E]
 basepython = python3.5
@@ -92,26 +34,6 @@ basepython = python3.5
 deps = {[testenv]deps}
     Django>=2.2,<2.3
 
-[testenv:py36-A]
-basepython = python3.6
-deps = {[testenv]deps}
-    Django>=1.8,<1.9
-
-[testenv:py36-B]
-basepython = python3.6
-deps = {[testenv]deps}
-    Django>=1.9,<1.10
-
-[testenv:py36-C]
-basepython = python3.6
-deps = {[testenv]deps}
-    Django>=1.10,<1.11
-
-[testenv:py36-D]
-basepython = python3.6
-deps = {[testenv]deps}
-    Django>=1.11,<2.0
-
 [testenv:py36-E]
 basepython = python3.6
 deps = {[testenv]deps}
@@ -127,26 +49,6 @@ basepython = python3.6
 deps = {[testenv]deps}
     Django>=2.2,<2.3
 
-[testenv:py37-A]
-basepython = python3.7
-deps = {[testenv]deps}
-    Django>=1.8,<1.9
-
-[testenv:py37-B]
-basepython = python3.7
-deps = {[testenv]deps}
-    Django>=1.9,<1.10
-
-[testenv:py37-C]
-basepython = python3.7
-deps = {[testenv]deps}
-    Django>=1.10,<1.11
-
-[testenv:py37-D]
-basepython = python3.7
-deps = {[testenv]deps}
-    Django>=1.11,<2.0
-
 [testenv:py37-E]
 basepython = python3.7
 deps = {[testenv]deps}
@@ -161,4 +63,129 @@ deps = {[testenv]deps}
 basepython = python3.7
 deps = {[testenv]deps}
     Django>=2.2,<2.3
+
+[testenv:py37-H]
+basepython = python3.7
+deps = {[testenv]deps}
+    Django>=3.0,<3.1
+
+[testenv:py37-I]
+basepython = python3.7
+deps = {[testenv]deps}
+    Django>=3.1,<3.2
+
+[testenv:py37-J]
+basepython = python3.7
+deps = {[testenv]deps}
+    Django>=3.2,<4.0
+
+[testenv:py37-K]
+basepython = python3.7
+deps = {[testenv]deps}
+    Django>=4.0,<4.1
+
+[testenv:py38-E]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=2.0,<2.1
+
+[testenv:py38-F]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=2.1,<2.2
+
+[testenv:py38-G]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=2.2,<2.3
+
+[testenv:py38-H]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=3.0,<3.1
+
+[testenv:py38-I]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=3.1,<3.2
+
+[testenv:py38-J]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=3.2,<4.0
+
+[testenv:py38-K]
+basepython = python3.8
+deps = {[testenv]deps}
+    Django>=4.0,<4.1
+
+[testenv:py39-E]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=2.0,<2.1
+
+[testenv:py39-F]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=2.1,<2.2
+
+[testenv:py39-G]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=2.2,<2.3
+
+[testenv:py39-H]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=3.0,<3.1
+
+[testenv:py39-I]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=3.1,<3.2
+
+[testenv:py39-J]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=3.2,<4.0
+
+[testenv:py39-K]
+basepython = python3.9
+deps = {[testenv]deps}
+    Django>=4.0,<4.1
+
+[testenv:py310-E]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=2.0,<2.1
+
+[testenv:py310-F]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=2.1,<2.2
+
+[testenv:py310-G]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=2.2,<2.3
+
+[testenv:py310-H]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=3.0,<3.1
+
+[testenv:py310-I]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=3.1,<3.2
+
+[testenv:py310-J]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=3.2,<4.0
+
+[testenv:py310-K]
+basepython = python3.10
+deps = {[testenv]deps}
+    Django>=4.0,<4.1
 


### PR DESCRIPTION
There is few features deprecated at least since Django 3.1 which is no compatible with latest release Django 4.0:

- `providing_args` in signals is deprecated since django 3.1
- `url` was for a while used as an alias for `re_path` for backward compatibility and now was removed from Django 4.0
- `deleted_at__isnull=**0**` cause error in Django 4.0, so i replace it by `False` instead.

I tested this changes wit python 3.7, 3.8, 3.9, 3.10. Minimal supported Django version with this changes is Django 2.0 (or 2.2 in case of python 3.10), which is more than reasonable, since Django 2.2 LTS support will end in Abril 2022.

Also in `tox.ini` was added new Django and Python versions and removed unsupported versions if this PR will be merged.

_Test summary before cleanup of unsupported versions from `tox.ini`. E suffix is a Django 2.0_

![Test summary before cleanup of unsupported versions from `tox.ini`](https://user-images.githubusercontent.com/35577127/148324902-1362a915-2e24-4f64-884d-9d79c3674c33.png)
