### PR TITLE
Respect ForeignKey on_delete: SET_NULL, DO_NOTHING

### DIFF
--- a/softdelete/settings.py
+++ b/softdelete/settings.py
@@ -54,6 +54,7 @@ TEMPLATES = [
              'context_processors': (
                  'django.contrib.messages.context_processors.messages',
                  'django.contrib.auth.context_processors.auth',
+                 'django.template.context_processors.request'
              )
          }
     },

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -3,10 +3,12 @@ from django.contrib import admin
 from softdelete.models import *
 from softdelete.admin import *
 
+
 class TestModelOne(SoftDeleteObject):
     extra_bool = models.BooleanField(default=False)
 
-class TestModelTwo(SoftDeleteObject):
+
+class TestModelTwoCascade(SoftDeleteObject):
     extra_int = models.IntegerField()
     tmo = models.ForeignKey(
         TestModelOne,
@@ -14,9 +16,31 @@ class TestModelTwo(SoftDeleteObject):
         related_name='tmts'
     )
 
+
+class TestModelTwoDoNothing(SoftDeleteObject):
+    extra_int = models.IntegerField()
+    tmo = models.ForeignKey(
+        TestModelOne,
+        on_delete=models.DO_NOTHING,
+        related_name='tmdn'
+    )
+
+
+class TestModelTwoSetNull(SoftDeleteObject):
+    extra_int = models.IntegerField()
+    tmo = models.ForeignKey(
+        TestModelOne,
+        on_delete=models.SET_NULL,
+        related_name='tmsn',
+        null=True,
+        blank=True
+    )
+
+
 class TestModelThree(SoftDeleteObject):
     tmos = models.ManyToManyField(TestModelOne, through='TestModelThrough')
     extra_int = models.IntegerField(blank=True, null=True)
+
 
 class TestModelThrough(SoftDeleteObject):
     tmo1 = models.ForeignKey(
@@ -32,7 +56,9 @@ class TestModelThrough(SoftDeleteObject):
 
 
 admin.site.register(TestModelOne, SoftDeleteObjectAdmin)
-admin.site.register(TestModelTwo, SoftDeleteObjectAdmin)
+admin.site.register(TestModelTwoCascade, SoftDeleteObjectAdmin)
+admin.site.register(TestModelTwoSetNull, SoftDeleteObjectAdmin)
+admin.site.register(TestModelTwoDoNothing, SoftDeleteObjectAdmin)
+
 admin.site.register(TestModelThree, SoftDeleteObjectAdmin)
 admin.site.register(TestModelThrough, SoftDeleteObjectAdmin)
-

--- a/softdelete/tests/constanats.py
+++ b/softdelete/tests/constanats.py
@@ -1,0 +1,12 @@
+from softdelete.test_softdelete_app.models import TestModelTwoCascade, TestModelTwoDoNothing, TestModelTwoSetNull
+
+TEST_MODEL_ONE_COUNT = 2
+TEST_MODEL_TWO_TOTAL_COUNT = 12  # should be multiple of LCM(TEST_MODEL_ONE_COUNT,TEST_MODEL_TWO_COUNT),
+# here LCM is 6 and multiplier is 2
+
+TEST_MODEL_THREE_COUNT = TEST_MODEL_TWO_TOTAL_COUNT ** 2
+TEST_MODEL_TWO_LIST = [TestModelTwoCascade,
+                       TestModelTwoDoNothing,
+                       TestModelTwoSetNull]
+TEST_MODEL_TWO_CASCADE_COUNT = TEST_MODEL_TWO_DO_NOTHING_COUNT = TEST_MODEL_TWO_SET_NULL_COUNT = \
+    TEST_MODEL_TWO_TOTAL_COUNT // len(TEST_MODEL_TWO_LIST)

--- a/softdelete/tests/test_views.py
+++ b/softdelete/tests/test_views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.db import models
-from softdelete.test_softdelete_app.models import TestModelOne, TestModelTwo, TestModelThree
+from softdelete.test_softdelete_app.models import TestModelOne, TestModelTwoCascade, TestModelThree
 from softdelete.models import *
 from softdelete.signals import *
 import logging
@@ -29,11 +29,12 @@ class ViewBase(TestCase):
         self.tmo1 = TestModelOne.objects.create(extra_bool=True)
         self.tmo3 = TestModelThree.objects.create(extra_int=3)
         for x in range(10):
-            TestModelTwo.objects.create(extra_int=x, tmo=self.tmo1)
+            TestModelTwoCascade.objects.create(extra_int=x, tmo=self.tmo1)
         self.tmo2 = TestModelOne.objects.create(extra_bool=False)
         for x in range(10):
-            TestModelTwo.objects.create(extra_int=x*x, tmo=self.tmo2)
+            TestModelTwoCascade.objects.create(extra_int=x * x, tmo=self.tmo2)
         self.tmo2.delete()
+
 
 class ViewTest(ViewBase):
     def __init__(self, *args, **kwargs):
@@ -83,6 +84,7 @@ class ViewTest(ViewBase):
         self.assertEquals(self.rs_count, SoftDeleteRecord.objects.count())
         self.assertEquals(self.t_count, TestModelThree.objects.count())
         self.assertEquals(0, self.tmo3.tmos.count())
+
 
 class GroupViewTest(ViewTest):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
- respect foreign-key on_delete value: SET_NULL, DO_NOTHING 
- delete operation warped in transaction, in order to prevent dangling state
- PEP8 formation
- updated test cases
- resolved admin.W411 warning 
- will resolve #70  #45 #42  