### PR TITLE
Declare id to be BigAutoField explicitly

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -280,6 +280,9 @@ class SoftDeleteObject(models.Model):
                 self.delete()
 
 class ChangeSet(models.Model):
+    id = models.BigAutoField(
+        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+    )    
     created_date = models.DateTimeField(default=timezone.now)
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.CharField(max_length=100)
@@ -312,6 +315,9 @@ class ChangeSet(models.Model):
     content = property(get_content, set_content)
 
 class SoftDeleteRecord(models.Model):
+    id = models.BigAutoField(
+        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+    )    
     changeset = models.ForeignKey(
         ChangeSet,
         related_name='soft_delete_records',


### PR DESCRIPTION
Running `makemigrations` in Django 3.2+ with `DEFAULT_AUTO_FIELD` set to `django.db.models.AutoField` will generate extra migrations for this package, this PR will fix it.

Reason:
* On Django 3.2+, by default the auto field is determined by `DEFAULT_AUTO_FIELD` in settings
* Current version works if it is set to `BigAutoField`, as the migration is added in #83.
* However when it is set to `AutoField`, it will apply to both models in the package, generating a migration.

And since we need to maintain compatibility to more Django version and `default_auto_field` in `AppConfig` is only supported in 3.2+, we need to explicitly declare `id` field to both models. I had checked it should not generate extra migration in my cases.