### PR TITLE
Persist change on related model instance

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -244,13 +244,16 @@ class SoftDeleteObject(models.Model):
                 if x.on_delete.__name__ not in ['DO_NOTHING', 'SET_NULL']:
                     self._do_delete(cs, x)
                 if x.on_delete.__name__ == 'SET_NULL':
-                    rel = x.get_accessor_name()
+                    related_name = x.get_accessor_name()
                     if isinstance(x, OneToOneRel):
-                        if not getattr(self, rel, None):
+                        if getattr(self, related_name, None) is None:
                             continue
-                        setattr(getattr(self, rel), x.remote_field.name, None)
+                        related = getattr(self, related_name)
+                        if isinstance(related, models.Model):
+                            setattr(related, x.remote_field.name, None)
+                            related.save(update_fields=[x.remote_field.name])
                     else:
-                        getattr(self, rel).all().update(**{x.remote_field.name: None})
+                        getattr(self, related_name).all().update(**{x.remote_field.name: None})
             logging.debug("FINISHED SOFT DELETING RELATED %s", self)
             models.signals.post_delete.send(sender=self.__class__,
                                             instance=self,

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -37,6 +37,17 @@ class TestModelTwoSetNull(SoftDeleteObject):
     )
 
 
+class TestModelTwoSetNullOneToOne(SoftDeleteObject):
+    extra_int = models.IntegerField()
+    tmo = models.OneToOneField(
+        TestModelOne,
+        on_delete=models.SET_NULL,
+        related_name='tmsno',
+        null=True,
+        blank=True
+    )
+
+
 class TestModelThree(SoftDeleteObject):
     tmos = models.ManyToManyField(TestModelOne, through='TestModelThrough')
     extra_int = models.IntegerField(blank=True, null=True)


### PR DESCRIPTION
A couple things are functionally different here:
 * Check that we're actually dealing with an instance of a model.
 * Also call `save()` on the related instance.

As this extends the brilliant `on_delete` work from you, @PratikBodawala, I'd appreciate your feedback if you have the time for it.