### PR TITLE
Prevent all model entities from being deleted for OneToOneField relations

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -183,7 +183,10 @@ class SoftDeleteObject(models.Model):
                 getattr(self, rel).all().delete(changeset=changeset)
         except:
             try:
-                getattr(self, rel).all().delete()
+                if related.one_to_one:
+                    getattr(self, rel).delete()
+                else:
+                    getattr(self, rel).all().delete()
             except:
                 try:
                     getattr(self, rel).__class__.objects.all().delete(

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -78,6 +78,15 @@ class TestModelO2OFemaleCascade(SoftDeleteObject):
     )
 
 
+class TestModelO2OFemaleCascadeNoSD(models.Model):
+    name = models.CharField(max_length=16)
+    link = models.OneToOneField(
+        TestModelBaseO2OMale,
+        related_name='one_to_one_cascade_no_sd',
+        on_delete=models.CASCADE
+    )
+
+
 admin.site.register(TestModelOne, SoftDeleteObjectAdmin)
 admin.site.register(TestModelTwoCascade, SoftDeleteObjectAdmin)
 admin.site.register(TestModelTwoSetNull, SoftDeleteObjectAdmin)

--- a/softdelete/tests/test_sd.py
+++ b/softdelete/tests/test_sd.py
@@ -4,7 +4,8 @@ from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.db import models
 from softdelete.test_softdelete_app.models import TestModelOne, TestModelTwoCascade, TestModelThree, TestModelThrough, \
-    TestModelTwoDoNothing, TestModelTwoSetNull, TestModelO2OFemaleSetNull, TestModelBaseO2OMale, TestModelO2OFemaleCascade
+    TestModelTwoDoNothing, TestModelTwoSetNull, TestModelO2OFemaleSetNull, TestModelBaseO2OMale, \
+    TestModelO2OFemaleCascade, TestModelO2OFemaleCascadeNoSD
 from softdelete.tests.constanats import TEST_MODEL_ONE_COUNT, TEST_MODEL_TWO_TOTAL_COUNT, TEST_MODEL_THREE_COUNT, \
     TEST_MODEL_TWO_LIST, TEST_MODEL_TWO_CASCADE_COUNT, TEST_MODEL_TWO_SET_NULL_COUNT, TEST_MODEL_TWO_DO_NOTHING_COUNT
 from softdelete.models import *
@@ -367,3 +368,13 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
 
         self.assertRaises(TestModelO2OFemaleCascade.DoesNotExist, TestModelO2OFemaleCascade.objects.get, name='Juliet')
         self.assertEquals(juliet.deleted, True)
+
+        kurt = TestModelBaseO2OMale.objects.create(name='Kurt')
+        courtney = TestModelO2OFemaleCascadeNoSD.objects.create(name='Courtney', link=kurt)
+        jack = TestModelBaseO2OMale.objects.create(name='Jack')
+        jill = TestModelO2OFemaleCascadeNoSD.objects.create(name='jill', link=jack)
+
+        kurt.delete()
+
+        self.assertTrue(TestModelO2OFemaleCascadeNoSD.objects.filter(id=jill.id).exists())
+        self.assertFalse(TestModelO2OFemaleCascadeNoSD.objects.filter(id=courtney.id).exists())


### PR DESCRIPTION
Fixes #99 

As an extra thought, I am wondering whether there should be some configuration (either in the settings or on the models themselves) as to whether the `__class__.objects..all().delete()` is EVER called. It seems super dangerous to me and I'm not sure what it achieves? I would suggest that this code should not be run by default. 

For our use case, for example, we would be looking for a couple of options perhaps: 

 1. **Just don't do anything.** Since the parent entity has been soft deleted, these entities can remain in the database without any referential integrity issues. This would work in cases where the OneToOne related fields are only shown in the context of their parent. 
 2. **Raise an exception.** Clearly something has gone awry but instead of deleting everything, we should surface an exception. 

I'd be keen to understand (here or on the issue I raised) what the logic behind adding these lines of code was so that a decision can be made on the above. 