### PR TITLE
Add setting to prevent all object deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Usage
 - If you have a custom manager also make sure to inherit from the `SoftDeleteManager`.
 - After that you can test it by __deleting__ and __undeleting__ objects from your models. Have fun undeleting :)
 
+Settings
+========
+
+|Name|Default| Description                                                                                                                                                                 |
+|---|---|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|`SOFTDELETE_CASCADE_ALLOW_DELETE_ALL`|True| Setting to confirm if the logic for deleting related entities should fall back to deleting all model entities in the event of an exception being raised when calling delete |
+
 How It Works
 ============
 
@@ -64,6 +71,13 @@ undelete.
 If you are undeleting an object that was part of a ChangeSet, that entire ChangeSet is undeleted.
 
 Once undeleted, the ChangeSet object is removed from the underlying database with a regular ("hard") delete.
+
+Warnings
+=====
+
+When using cascade delete, the default behaviour when the call to delete a related object raises an exception is 
+to fallback to deleting all the entities for that model class from the database. You can prevent this behaviour
+by using the `SOFTDELETE_CASCADE_ALLOW_DELETE_ALL` setting. Set this to `False` to prevent the behaviour.
 
 ## Testing
 

--- a/softdelete/test_softdelete_app/exceptions.py
+++ b/softdelete/test_softdelete_app/exceptions.py
@@ -1,0 +1,2 @@
+class ModelDeletionException(Exception):
+    pass

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -1,7 +1,10 @@
 from django.db import models
 from django.contrib import admin
+from django.db.models import QuerySet
+
 from softdelete.models import *
 from softdelete.admin import *
+from softdelete.test_softdelete_app.exceptions import ModelDeletionException
 
 
 class TestModelOne(SoftDeleteObject):
@@ -76,6 +79,18 @@ class TestModelO2OFemaleCascade(SoftDeleteObject):
         related_name='one_to_one_cascade',
         on_delete=models.CASCADE,
     )
+
+
+class TestModelO2OFemaleCascadeErrorOnDelete(models.Model):
+    name = models.CharField(max_length=16)
+    link = models.OneToOneField(
+        TestModelBaseO2OMale,
+        related_name='one_to_one_cascade_error_on_delete',
+        on_delete=models.CASCADE,
+    )
+
+    def delete(self, using=None, keep_parents=False):
+        raise ModelDeletionException("Preventing deletion!")
 
 
 admin.site.register(TestModelOne, SoftDeleteObjectAdmin)


### PR DESCRIPTION
Adds an optional setting (`SOFTDELETE_CASCADE_ALLOW_DELETE_ALL`) to prevent all model deletion. 

As mentioned in my other issues / PRs, I'm not entirely sure why this behaviour exists, however, this allows users to disable it. This is really only a temporary solution and this logic should be visited in a future major version (imo). 