### PR TITLE
Fixes invalid using argument.

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -227,7 +227,7 @@ class SoftDeleteObject(models.Model):
                 except:
                     pass
         else:
-            using = kwargs.get('using', settings.DATABASES['default'])
+            using = kwargs.get('using', 'default')
             models.signals.pre_delete.send(sender=self.__class__,
                                            instance=self,
                                            using=using)


### PR DESCRIPTION
There's quite serious bug in the source code. Argument to using should be the name of the connection, not the dict with the database connection settings itself.

It seems that the bug exists from the very beginning of the project, weird that it was never noticed. I guess that Django just ignores invalid using argument.

But it breaks deletion if you use django-softdelete and django-cacheops in the same application.