### PR TITLE
Change to new index_together syntax

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -305,8 +305,8 @@ class ChangeSet(models.Model):
     record = GenericForeignKey('content_type', 'object_id')
 
     class Meta:
-        index_together = [
-            ("content_type", "object_id"),
+        indexes = [
+            models.Index(fields=["content_type", "object_id"]),
         ]
 
     def get_content(self):
@@ -346,8 +346,8 @@ class SoftDeleteRecord(models.Model):
 
     class Meta:
         unique_together = (('changeset', 'content_type', 'object_id'),)
-        index_together = [
-            ("content_type", "object_id"),
+        indexes = [
+            models.Index(fields=["content_type", "object_id"]),
         ]
 
     def get_content(self):


### PR DESCRIPTION
Django has deprecated `index_together`. It will be removed in Django 5.1.

On my project I get this warning
```
/opt/venvs/web/lib/python3.11/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'softdelete.ChangeSet' instead.
  warnings.warn(
/opt/venvs/web/lib/python3.11/site-packages/django/db/models/options.py:210: RemovedInDjango51Warning: 'index_together' is deprecated. Use 'Meta.indexes' in 'softdelete.SoftDeleteRecord' instead.
  warnings.warn(
```

https://docs.djangoproject.com/en/5.0/ref/models/options/#django.db.models.Options.indexes