### PR TITLE
Add generic foreign key to object deletion

### DIFF
--- a/softdelete/models.py
+++ b/softdelete/models.py
@@ -247,6 +247,21 @@ class SoftDeleteObject(models.Model):
                 if (f.one_to_many or f.one_to_one)
                    and f.auto_created and not f.concrete
             ]
+            
+            all_generic_relations = [
+                f
+                for f in self._meta.get_fields()
+                if (f.one_to_many or f.one_to_one)
+                and hasattr(f, "reverse_related_fields")
+                and not f.concrete
+            ]
+
+            for generic_relation in all_generic_relations:
+                related_objects = generic_relation.bulk_related_objects(
+                    [self], using=using
+                )
+                for related_object in related_objects:
+                    related_object.delete()
 
             for x in all_related:
                 if x.on_delete.__name__ not in ['DO_NOTHING', 'SET_NULL']:

--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -5,10 +5,23 @@ from django.db.models import QuerySet
 from softdelete.models import *
 from softdelete.admin import *
 from softdelete.test_softdelete_app.exceptions import ModelDeletionException
+from django.contrib.contenttypes.models import ContentType
+try:
+    from django.contrib.contenttypes.fields import GenericRelation, GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericRelation, GenericForeignKey
 
 
 class TestModelOne(SoftDeleteObject):
     extra_bool = models.BooleanField(default=False)
+
+class TestGenericForeignKey(SoftDeleteObject):
+    content_type = models.ForeignKey(ContentType, on_delete=models.SET_NULL, null=True)
+    object_id = models.CharField(max_length=255, null=True)
+    generic_relation = GenericForeignKey("content_type", "object_id")
+
+class TestGenericRelation(SoftDeleteObject):
+    generic_relations = GenericRelation("ProjectRiskModel")
 
 
 class TestModelTwoCascade(SoftDeleteObject):


### PR DESCRIPTION
Adds a recursive check for generic relations and deletes them using their respective models' `delete` method