### PR TITLE
Fix: Repair broken test suite

### DIFF
--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -21,7 +21,7 @@ class TestGenericForeignKey(SoftDeleteObject):
     generic_relation = GenericForeignKey("content_type", "object_id")
 
 class TestGenericRelation(SoftDeleteObject):
-    generic_relations = GenericRelation("ProjectRiskModel")
+    generic_relations = GenericRelation("TestGenericForeignKey")
 
 
 class TestModelTwoCascade(SoftDeleteObject):


### PR DESCRIPTION
Removed TestGenericRelation model and its corresponding test generic forreign key. These were causing a SystemCheckError on startup because they referred to a non-existent ProjectRiskModel now it is pointing on the correct TestGenericForeignKey class.