### PR TITLE
Replace `assertEquals` with `assertEqual`

### DIFF
--- a/softdelete/test_softdelete_app/models.py
+++ b/softdelete/test_softdelete_app/models.py
@@ -21,7 +21,7 @@ class TestGenericForeignKey(SoftDeleteObject):
     generic_relation = GenericForeignKey("content_type", "object_id")
 
 class TestGenericRelation(SoftDeleteObject):
-    generic_relations = GenericRelation("ProjectRiskModel")
+    generic_relations = GenericRelation("TestGenericForeignKey")
 
 
 class TestModelTwoCascade(SoftDeleteObject):

--- a/softdelete/tests/test_sd.py
+++ b/softdelete/tests/test_sd.py
@@ -70,71 +70,71 @@ class BaseTest(TestCase):
 class InitialTest(BaseTest):
 
     def test_simple_delete(self):
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
 
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
 
         self.tmo1.delete()
 
-        self.assertEquals(TEST_MODEL_ONE_COUNT - 1, TestModelOne.objects.count())
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT - 1, TestModelOne.objects.count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT - 2, TestModelTwoCascade.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT - 2, TestModelTwoCascade.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
 
     def test_simple_multi_delete(self):
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
 
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
 
         self.tmo1.delete()
         self.tmo2.delete()
 
-        self.assertEquals(TEST_MODEL_ONE_COUNT - 2, TestModelOne.objects.count())
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT - 2, TestModelOne.objects.count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT - 4, TestModelTwoCascade.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT - 4, TestModelTwoCascade.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
 
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.all_with_deleted().count())
 
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.all_with_deleted().count())
 
 
 class DeleteTest(BaseTest):
@@ -159,11 +159,11 @@ class DeleteTest(BaseTest):
         models.signals.post_delete.connect(self.post_delete)
         pre_soft_delete.connect(self.pre_soft_delete)
         post_soft_delete.connect(self.post_soft_delete)
-        self.assertEquals(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
-        self.assertEquals(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
-        self.assertEquals(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
+        self.assertEqual(TEST_MODEL_ONE_COUNT, TestModelOne.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_CASCADE_COUNT, TestModelTwoCascade.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_SET_NULL_COUNT, TestModelTwoSetNull.objects.count())
+        self.assertEqual(TEST_MODEL_TWO_DO_NOTHING_COUNT, TestModelTwoDoNothing.objects.count())
+        self.assertEqual(TEST_MODEL_THREE_COUNT, TestModelThree.objects.count())
         self.assertFalse(self.tmo1.deleted)
         self.assertFalse(self.pre_delete_called)
         self.assertFalse(self.post_delete_called)
@@ -186,8 +186,8 @@ class DeleteTest(BaseTest):
     def test_delete(self):
         self._pretest()
         self.tmo1.delete()
-        self.assertEquals(self.cs_count + 1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
+        self.assertEqual(self.cs_count + 1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
                                            + TEST_MODEL_TWO_CASCADE_COUNT // 2  # half assigned to cascade model two
                                            + 1  # tmo1 itself
                                            ), SoftDeleteRecord.objects.count())
@@ -197,11 +197,11 @@ class DeleteTest(BaseTest):
         self._pretest()
         tmo_tmp = TestModelOne.objects.create(extra_bool=True)
         tmo_tmp.delete()
-        self.assertEquals(self.cs_count + 1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count + 1, SoftDeleteRecord.objects.count())
+        self.assertEqual(self.cs_count + 1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count + 1, SoftDeleteRecord.objects.count())
         tmo_tmp.delete()
-        self.assertEquals(self.cs_count, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count, SoftDeleteRecord.objects.count())
+        self.assertEqual(self.cs_count, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count, SoftDeleteRecord.objects.count())
         self.assertRaises(TestModelOne.DoesNotExist,
                           TestModelOne.objects.get,
                           pk=tmo_tmp.pk)
@@ -209,8 +209,8 @@ class DeleteTest(BaseTest):
     def test_filter_delete(self):
         self._pretest()
         TestModelOne.objects.filter(pk=1).delete()
-        self.assertEquals(self.cs_count + 1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
+        self.assertEqual(self.cs_count + 1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
                                            + TEST_MODEL_TWO_CASCADE_COUNT // 2  # half assigned to cascade model two
                                            + 1  # tmo1 itself
                                            ), SoftDeleteRecord.objects.count())
@@ -269,9 +269,9 @@ class AdminTest(BaseTest):
         if tmo.status_code == 302 and tmo['Location'].endswith('change/') and (1, 9) <= django.VERSION:
             url = tmo['Location']
             tmo = client.get(url)
-        self.assertEquals(tmo.status_code, 200)
+        self.assertEqual(tmo.status_code, 200)
         tmo = client.post(url, {'extra_bool': '1', 'deleted': '1'})
-        self.assertEquals(tmo.status_code, 302)
+        self.assertEqual(tmo.status_code, 302)
         self.tmo1 = TestModelOne.objects.get(pk=self.tmo1.pk)
         self.assertTrue(self.tmo1.deleted)
 
@@ -282,11 +282,11 @@ class AuthorizationTest(BaseTest):
         cl.login(username='NonSoftdeleteUser',
                  password='NonSoftdeletePassword')
         rv = cl.get(reverse('softdelete.changeset.list'))
-        self.assertEquals(rv.status_code, 302)
+        self.assertEqual(rv.status_code, 302)
         rv = cl.get(reverse('softdelete.changeset.view', args=(1,)))
-        self.assertEquals(rv.status_code, 302)
+        self.assertEqual(rv.status_code, 302)
         rv = cl.get(reverse('softdelete.changeset.undelete', args=(1,)))
-        self.assertEquals(rv.status_code, 302)
+        self.assertEqual(rv.status_code, 302)
 
 
 class UndeleteTest(BaseTest):
@@ -306,8 +306,8 @@ class UndeleteTest(BaseTest):
         self.cs_count = ChangeSet.objects.count()
         self.rs_count = SoftDeleteRecord.objects.count()
         self.tmo1.delete()
-        self.assertEquals(self.cs_count + 1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
+        self.assertEqual(self.cs_count + 1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
                                            + TEST_MODEL_TWO_CASCADE_COUNT // 2  # half assigned to cascade model two
                                            + 1  # tmo1 itself
                                            ), SoftDeleteRecord.objects.count())
@@ -316,8 +316,8 @@ class UndeleteTest(BaseTest):
         self.assertTrue(self.tmo1.deleted)
         self.assertFalse(self.tmo2.deleted)
         self.tmo1.undelete()
-        self.assertEquals(0, ChangeSet.objects.count())
-        self.assertEquals(0, SoftDeleteRecord.objects.count())
+        self.assertEqual(0, ChangeSet.objects.count())
+        self.assertEqual(0, SoftDeleteRecord.objects.count())
         self.tmo1 = TestModelOne.objects.get(pk=self.tmo1.pk)
         self.tmo2 = TestModelOne.objects.get(pk=self.tmo2.pk)
         self.assertFalse(self.tmo1.deleted)
@@ -326,8 +326,8 @@ class UndeleteTest(BaseTest):
         self.assertTrue(self.post_undelete_called)
 
         self.tmo1.delete()
-        self.assertEquals(self.cs_count + 1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
+        self.assertEqual(self.cs_count + 1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count + (TEST_MODEL_THREE_COUNT // 2  # half is assigned by tmo1
                                            + TEST_MODEL_TWO_CASCADE_COUNT // 2  # half assigned to cascade model two
                                            + 1  # tmo1 itself
                                            ), SoftDeleteRecord.objects.count())
@@ -336,8 +336,8 @@ class UndeleteTest(BaseTest):
         self.assertTrue(self.tmo1.deleted)
         self.assertFalse(self.tmo2.deleted)
         TestModelOne.objects.deleted_set().undelete()
-        self.assertEquals(0, ChangeSet.objects.count())
-        self.assertEquals(0, SoftDeleteRecord.objects.count())
+        self.assertEqual(0, ChangeSet.objects.count())
+        self.assertEqual(0, SoftDeleteRecord.objects.count())
         self.tmo1 = TestModelOne.objects.get(pk=self.tmo1.pk)
         self.tmo2 = TestModelOne.objects.get(pk=self.tmo2.pk)
         self.assertFalse(self.tmo1.deleted)
@@ -362,18 +362,18 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
         tmt1 = TestModelTwoCascade.objects.create(extra_int=100, tmo=self.tmo1)
         tmt2 = TestModelTwoCascade.objects.create(extra_int=100, tmo=self.tmo2)
 
-        self.assertEquals(self.tmo1.tmts.filter(extra_int=100).count(), 1)
-        self.assertEquals(self.tmo1.tmts.filter(extra_int=100)[0].pk, tmt1.pk)
-        self.assertEquals(self.tmo2.tmts.filter(extra_int=100).count(), 1)
-        self.assertEquals(self.tmo2.tmts.filter(extra_int=100)[0].pk, tmt2.pk)
+        self.assertEqual(self.tmo1.tmts.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo1.tmts.filter(extra_int=100)[0].pk, tmt1.pk)
+        self.assertEqual(self.tmo2.tmts.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo2.tmts.filter(extra_int=100)[0].pk, tmt2.pk)
 
-        self.assertEquals(self.tmo1.tmts.get(extra_int=100), tmt1)
-        self.assertEquals(self.tmo2.tmts.get(extra_int=100), tmt2)
+        self.assertEqual(self.tmo1.tmts.get(extra_int=100), tmt1)
+        self.assertEqual(self.tmo2.tmts.get(extra_int=100), tmt2)
 
         tmt1.delete()
-        self.assertEquals(self.tmo1.tmts.filter(extra_int=100).count(), 0)
+        self.assertEqual(self.tmo1.tmts.filter(extra_int=100).count(), 0)
         tmt1.undelete()
-        self.assertEquals(self.tmo1.tmts.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo1.tmts.filter(extra_int=100).count(), 1)
 
         tmt1.delete()
         tmt1.delete()
@@ -386,18 +386,18 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
         t32 = TestModelThree.objects.create(extra_int=100)
         TestModelThrough.objects.create(tmo1=self.tmo2, tmo3=t32)
 
-        self.assertEquals(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 1)
-        self.assertEquals(self.tmo1.testmodelthree_set.filter(extra_int=100)[0].pk, t31.pk)
-        self.assertEquals(self.tmo2.testmodelthree_set.filter(extra_int=100).count(), 1)
-        self.assertEquals(self.tmo2.testmodelthree_set.filter(extra_int=100)[0].pk, t32.pk)
+        self.assertEqual(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo1.testmodelthree_set.filter(extra_int=100)[0].pk, t31.pk)
+        self.assertEqual(self.tmo2.testmodelthree_set.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo2.testmodelthree_set.filter(extra_int=100)[0].pk, t32.pk)
 
-        self.assertEquals(self.tmo1.testmodelthree_set.get(extra_int=100), t31)
-        self.assertEquals(self.tmo2.testmodelthree_set.get(extra_int=100), t32)
+        self.assertEqual(self.tmo1.testmodelthree_set.get(extra_int=100), t31)
+        self.assertEqual(self.tmo2.testmodelthree_set.get(extra_int=100), t32)
 
         t31.delete()
-        self.assertEquals(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 0)
+        self.assertEqual(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 0)
         t31.undelete()
-        self.assertEquals(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 1)
+        self.assertEqual(self.tmo1.testmodelthree_set.filter(extra_int=100).count(), 1)
 
         t31.delete()
         t31.delete()
@@ -410,7 +410,7 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
 
         bob.delete()
 
-        self.assertEquals(alice.link_id, None)
+        self.assertEqual(alice.link_id, None)
 
         romeo = TestModelBaseO2OMale.objects.create(name='Romeo')
         juliet = TestModelO2OFemaleCascade.objects.create(name='Juliet', link=romeo)
@@ -418,7 +418,7 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
         romeo.delete()
 
         self.assertRaises(TestModelO2OFemaleCascade.DoesNotExist, TestModelO2OFemaleCascade.objects.get, name='Juliet')
-        self.assertEquals(juliet.deleted, True)
+        self.assertEqual(juliet.deleted, True)
 
         kurt = TestModelBaseO2OMale.objects.create(name='Kurt')
         courtney = TestModelO2OFemaleCascadeNoSD.objects.create(name='Courtney', link=kurt)
@@ -450,4 +450,4 @@ class SoftDeleteRelatedFieldLookupsTests(BaseTest):
 
         self.assertRaises(ModelDeletionException, alice.delete)
         self.assertTrue(TestModelO2OFemaleCascadeErrorOnDelete.objects.filter(id=alice.id).exists())
-        self.assertEquals(TestModelO2OFemaleCascadeErrorOnDelete.objects.count(), 2)
+        self.assertEqual(TestModelO2OFemaleCascadeErrorOnDelete.objects.count(), 2)

--- a/softdelete/tests/test_views.py
+++ b/softdelete/tests/test_views.py
@@ -58,7 +58,7 @@ class ViewTest(ViewBase):
             cli2 = Client()
             rv = cli2.get(view_name)
             # Make sure we redirected to a login page
-            self.assertEquals(rv.status_code, 302)
+            self.assertEqual(rv.status_code, 302)
             self.assertIn(reverse('login'), rv['Location'])
             # But don't try to render it.
 
@@ -67,23 +67,23 @@ class ViewTest(ViewBase):
         self.rs_count = SoftDeleteRecord.objects.count()
         self.t_count = TestModelThree.objects.count()
         self.tmo3.delete()
-        self.assertEquals(self.t_count-1, TestModelThree.objects.count())
-        self.assertEquals(0, self.tmo3.tmos.count())
-        self.assertEquals(self.cs_count+1, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count+1, SoftDeleteRecord.objects.count())
+        self.assertEqual(self.t_count-1, TestModelThree.objects.count())
+        self.assertEqual(0, self.tmo3.tmos.count())
+        self.assertEqual(self.cs_count+1, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count+1, SoftDeleteRecord.objects.count())
         rv = self.client.get(reverse("softdelete.changeset.undelete",
                                      args=(ChangeSet.objects.latest("created_date").pk,)))
-        self.assertEquals(rv.status_code,200)
+        self.assertEqual(rv.status_code,200)
         rv = self.client.post(reverse("softdelete.changeset.undelete",
                                      args=(ChangeSet.objects.latest("created_date").pk,)),
                              {'action': 'Undelete'})
-        self.assertEquals(rv.status_code, 302)
+        self.assertEqual(rv.status_code, 302)
         rv = self.client.get(rv['Location'])
-        self.assertEquals(rv.status_code, 200)
-        self.assertEquals(self.cs_count, ChangeSet.objects.count())
-        self.assertEquals(self.rs_count, SoftDeleteRecord.objects.count())
-        self.assertEquals(self.t_count, TestModelThree.objects.count())
-        self.assertEquals(0, self.tmo3.tmos.count())
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(self.cs_count, ChangeSet.objects.count())
+        self.assertEqual(self.rs_count, SoftDeleteRecord.objects.count())
+        self.assertEqual(self.t_count, TestModelThree.objects.count())
+        self.assertEqual(0, self.tmo3.tmos.count())
 
 
 class GroupViewTest(ViewTest):


### PR DESCRIPTION
The former has been deprecated since Python 3.2 (2011) and completely removed in Python 3.12 (2023).

This also includes the generic relation fix from #112, in order to make tests pass.